### PR TITLE
Modernise charm to current ops idioms (load_config, load_params, collect_unit_status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- N/A (initial release)
-
-### Deprecated
-
-- N/A
+- Adopt typed configuration via `ops.CharmBase.load_config()` with a Pydantic
+  `BeszelConfig` model, removing the hand-written `from_charm_config` mapping
+- Adopt typed action parameters via `ActionEvent.load_params()` with a
+  `CreateAgentTokenParams` dataclass
+- Report unit status from a single `collect_unit_status` handler instead of
+  setting status imperatively across event handlers
+- Publish the configured `port` to the ingress requirer instead of a
+  hard-coded `8090`, and keep it in sync on configuration changes
+- Unit tests now autoload metadata from `charmcraft.yaml` (no `meta`/`config`/
+  `actions` overrides passed to `testing.Context`) and exercise the workload
+  module against a real Pebble filesystem; coverage raised to ~92%
+- `charmcraft.yaml` now declares an `assumes` block (`juju >= 3.6`, `k8s-api`)
+  and `additionalProperties: false` on every action
 
 ### Removed
 
-- N/A
+- Blocking `beszel.wait_for_ready` / `beszel.is_ready` readiness polling
+  (with `time.sleep`); readiness is handled by the Pebble `ready` health check
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Beszel is a lightweight server monitoring solution that tracks system metrics, D
 
 ## Requirements
 
-- Juju >= 3.1
+- Juju >= 3.6
 - Kubernetes cluster
 - Storage provider (for persistent volume)
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,6 +24,11 @@ platforms:
   amd64:
   arm64:
 
+# Fail fast on controllers that cannot run this charm.
+assumes:
+  - juju >= 3.6
+  - k8s-api
+
 parts:
   charm:
     plugin: uv
@@ -138,9 +143,11 @@ requires:
 actions:
   get-admin-url:
     description: Get the URL to access the Beszel Hub admin interface
+    additionalProperties: false
 
   create-agent-token:
     description: Create a universal token for agent authentication
+    additionalProperties: false
     params:
       description:
         description: Description for the token
@@ -149,6 +156,8 @@ actions:
 
   backup-now:
     description: Trigger an immediate backup
+    additionalProperties: false
 
   list-backups:
     description: List available backups
+    additionalProperties: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
+fail_under = 80
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/beszel.py
+++ b/src/beszel.py
@@ -8,12 +8,8 @@ from __future__ import annotations
 import logging
 import secrets
 import time
-from typing import TYPE_CHECKING
 
 import ops
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -41,49 +37,6 @@ def get_version(container: ops.Container) -> str | None:
     if version:
         return version
     return None
-
-
-def wait_for_ready(container: ops.Container, timeout: int = 30, port: int = 8090) -> bool:
-    """Wait for Beszel to be ready to serve requests.
-
-    Args:
-        container: The workload container
-        timeout: Maximum time to wait in seconds
-        port: Port Beszel is listening on
-
-    Returns:
-        True if ready, False if timeout
-    """
-    end_time = time.time() + timeout
-
-    while time.time() < end_time:
-        if is_ready(container, port):
-            return True
-        time.sleep(1)
-
-    logger.error("Beszel did not become ready within %d seconds", timeout)
-    return False
-
-
-def is_ready(container: ops.Container, port: int = 8090) -> bool:
-    """Check if Beszel is ready to serve requests.
-
-    Args:
-        container: The workload container
-        port: Port Beszel is listening on
-
-    Returns:
-        True if ready, False otherwise
-    """
-    for name, service_info in container.get_services().items():
-        if not service_info.is_running():
-            logger.debug("Service '%s' is not running", name)
-            return False
-
-    # Service is running - give it a moment to start accepting connections
-    # The Pebble HTTP health check will monitor ongoing availability
-    time.sleep(2)
-    return True
 
 
 def create_agent_token(container: ops.Container, description: str = "") -> str | None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,110 +6,92 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
-from typing import TYPE_CHECKING
 
 import ops
+import pydantic
 from charms.data_platform_libs.v0 import s3
 from charms.hydra.v0 import oauth
 from charms.traefik_k8s.v2 import ingress
-from pydantic import BaseModel, Field
 
 import beszel
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
 CONTAINER_NAME = "beszel"
 SERVICE_NAME = "beszel"
-BESZEL_DATA_DIR = "/beszel_data"
+CHECK_NAME = "beszel-ready"
+DEFAULT_PORT = 8090
 
 
-class BeszelConfig(BaseModel):
+class BeszelConfig(pydantic.BaseModel):
     """Configuration for Beszel Hub.
 
     Attrs:
-        container_image: OCI image to use for Beszel Hub
-        port: Port on which Beszel Hub listens
-        external_hostname: External hostname for OAuth callbacks
-        s3_backup_enabled: Enable S3 backups
-        s3_endpoint: S3 endpoint URL
-        s3_bucket: S3 bucket name
-        s3_region: S3 region
-        log_level: Log verbosity level
+        container_image: OCI image to use for Beszel Hub.
+        port: Port on which Beszel Hub listens.
+        external_hostname: External hostname for OAuth callbacks.
+        s3_backup_enabled: Enable S3 backups.
+        s3_endpoint: S3 endpoint URL.
+        s3_bucket: S3 bucket name.
+        s3_region: S3 region.
+        log_level: Log verbosity level.
     """
 
-    container_image: str = Field(default="henrygd/beszel:latest")
-    port: int = Field(default=8090, ge=1, le=65535)
-    external_hostname: str = Field(default="")
-    s3_backup_enabled: bool = Field(default=False)
-    s3_endpoint: str = Field(default="")
-    s3_bucket: str = Field(default="")
-    s3_region: str = Field(default="us-east-1")
-    log_level: str = Field(default="info")
+    container_image: str = "henrygd/beszel:latest"
+    port: int = pydantic.Field(default=DEFAULT_PORT, ge=1, le=65535)
+    external_hostname: str = ""
+    s3_backup_enabled: bool = False
+    s3_endpoint: str = ""
+    s3_bucket: str = ""
+    s3_region: str = "us-east-1"
+    log_level: str = "info"
 
-    @classmethod
-    def from_charm_config(cls, config: ops.ConfigData) -> BeszelConfig:
-        """Create configuration from charm config.
 
-        Args:
-            config: Charm configuration
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CreateAgentTokenParams:
+    """Parameters for the create-agent-token action.
 
-        Returns:
-            BeszelConfig instance
-        """
-        return cls(
-            container_image=str(config.get("container-image", "henrygd/beszel:latest")),
-            port=int(config.get("port", 8090)),
-            external_hostname=str(config.get("external-hostname", "")),
-            s3_backup_enabled=bool(config.get("s3-backup-enabled", False)),
-            s3_endpoint=str(config.get("s3-endpoint", "")),
-            s3_bucket=str(config.get("s3-bucket", "")),
-            s3_region=str(config.get("s3-region", "us-east-1")),
-            log_level=str(config.get("log-level", "info")),
-        )
+    Attrs:
+        description: Description to associate with the generated token.
+    """
+
+    description: str = ""
 
 
 class BeszelCharm(ops.CharmBase):
     """Charm for Beszel Hub."""
 
     def __init__(self, framework: ops.Framework):
-        """Initialize the charm.
-
-        Args:
-            framework: Ops framework
-        """
         super().__init__(framework)
 
         self.container = self.unit.get_container(CONTAINER_NAME)
 
-        # Relations
-        self.ingress = ingress.IngressPerAppRequirer(self, port=8090, strip_prefix=True)
+        # Relations. The ingress port is read directly from config (rather than
+        # via load_config) so that invalid config cannot raise during __init__.
+        self.ingress = ingress.IngressPerAppRequirer(
+            self, port=int(self.config.get("port", DEFAULT_PORT)), strip_prefix=True
+        )
         self.oauth = oauth.OAuthRequirer(self, client_config=self._get_oauth_client_config())
         self.s3 = s3.S3Requirer(self, "s3-credentials")
 
-        # Event handlers
         framework.observe(self.on[CONTAINER_NAME].pebble_ready, self._on_pebble_ready)
         framework.observe(
             self.on[CONTAINER_NAME].pebble_check_failed, self._on_pebble_check_failed
         )
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
+        framework.observe(self.on.collect_unit_status, self._on_collect_status)
 
-        # Ingress relation events
         framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
 
-        # OAuth relation events
         framework.observe(self.oauth.on.oauth_info_changed, self._on_oauth_info_changed)
 
-        # S3 relation events
         framework.observe(self.s3.on.credentials_changed, self._on_s3_credentials_changed)
         framework.observe(self.s3.on.credentials_gone, self._on_s3_credentials_gone)
 
-        # Actions
         framework.observe(self.on.get_admin_url_action, self._on_get_admin_url_action)
         framework.observe(self.on.create_agent_token_action, self._on_create_agent_token_action)
         framework.observe(self.on.backup_now_action, self._on_backup_now_action)
@@ -119,156 +101,120 @@ class BeszelCharm(ops.CharmBase):
         """Get OAuth client configuration.
 
         Returns:
-            OAuth client configuration if external hostname is set, None otherwise
+            OAuth client configuration if an external hostname is set, None otherwise.
         """
-        config = BeszelConfig.from_charm_config(self.config)
-
-        if not config.external_hostname:
+        external_hostname = str(self.config.get("external-hostname") or "")
+        if not external_hostname:
             return None
-
-        redirect_uri = f"https://{config.external_hostname}/_/#/auth/oidc"
-
         return oauth.ClientConfig(
-            redirect_uri=redirect_uri,
+            redirect_uri=f"https://{external_hostname}/_/#/auth/oidc",
             scope="openid profile email",
             grant_types=["authorization_code"],
         )
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
-        """Handle pebble-ready event.
-
-        Args:
-            event: Pebble ready event
-        """
         self._configure_workload()
 
     def _on_pebble_check_failed(self, event: ops.PebbleCheckFailedEvent) -> None:
-        """Handle pebble check failed event.
-
-        Args:
-            event: Pebble check failed event
-        """
+        # The on-check-failure action in the Pebble layer restarts the service;
+        # we just record that the check tripped.
         logger.warning("Pebble check '%s' failed", event.info.name)
-        # The on-check-failure action in the Pebble layer will restart the service
-        # We just log the event and let Pebble handle the recovery
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        """Handle config-changed event.
-
-        Args:
-            event: Config changed event
-        """
         self._configure_workload()
 
     def _on_upgrade_charm(self, event: ops.UpgradeCharmEvent) -> None:
-        """Handle upgrade-charm event.
-
-        Args:
-            event: Upgrade charm event
-        """
         self._configure_workload()
 
     def _on_ingress_ready(self, event: ingress.IngressPerAppReadyEvent) -> None:
-        """Handle ingress ready event.
-
-        Args:
-            event: Ingress ready event
-        """
         logger.info("Ingress is ready at %s", event.url)
         self._configure_workload()
 
     def _on_ingress_revoked(self, event: ingress.IngressPerAppRevokedEvent) -> None:
-        """Handle ingress revoked event.
-
-        Args:
-            event: Ingress revoked event
-        """
         logger.info("Ingress has been revoked")
         self._configure_workload()
 
     def _on_oauth_info_changed(self, event: oauth.OAuthInfoChangedEvent) -> None:
-        """Handle OAuth info changed event.
-
-        Args:
-            event: OAuth info changed event
-        """
         logger.info("OAuth information has changed")
         self._configure_workload()
 
     def _on_s3_credentials_changed(self, event: s3.CredentialsChangedEvent) -> None:
-        """Handle S3 credentials changed event.
-
-        Args:
-            event: S3 credentials changed event
-        """
         logger.info("S3 credentials have changed")
         self._configure_workload()
 
     def _on_s3_credentials_gone(self, event: s3.CredentialsGoneEvent) -> None:
-        """Handle S3 credentials gone event.
-
-        Args:
-            event: S3 credentials gone event
-        """
         logger.info("S3 credentials have been removed")
         self._configure_workload()
 
-    def _configure_workload(self) -> None:
-        """Configure the Beszel workload."""
-        if not self.container.can_connect():
-            self.unit.status = ops.WaitingStatus("Waiting for Pebble")
-            return
-
-        config = BeszelConfig.from_charm_config(self.config)
-
-        # Check for required storage
+    def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
+        """Report the unit status based on the current state of the workload."""
         try:
-            if not list(self.model.storages["beszel-data"]):
-                self.unit.status = ops.BlockedStatus("Storage not attached")
-                return
+            self.load_config(BeszelConfig)
+        except ValueError as e:
+            event.add_status(ops.BlockedStatus(f"Invalid configuration: {e}"))
+
+        if not self._storage_attached():
+            event.add_status(ops.BlockedStatus("Storage not attached"))
+
+        if not self.container.can_connect():
+            event.add_status(ops.WaitingStatus("Waiting for Pebble"))
+        else:
+            try:
+                service_running = self.container.get_service(SERVICE_NAME).is_running()
+            except (ops.ModelError, ops.pebble.ConnectionError):
+                service_running = False
+            if not service_running:
+                event.add_status(ops.MaintenanceStatus("Waiting for the service to start"))
+
+        event.add_status(ops.ActiveStatus())
+
+    def _storage_attached(self) -> bool:
+        """Report whether the beszel-data storage is attached."""
+        try:
+            return bool(list(self.model.storages["beszel-data"]))
         except (KeyError, ops.ModelError):
-            self.unit.status = ops.BlockedStatus("Storage not attached")
+            return False
+
+    def _configure_workload(self) -> None:
+        """Configure the Beszel workload.
+
+        Status is reported separately via the collect-status handler.
+        """
+        if not self.container.can_connect() or not self._storage_attached():
             return
 
-        # Build environment variables
+        try:
+            config = self.load_config(BeszelConfig)
+        except ValueError:
+            # The collect-status handler reports the configuration error.
+            return
+
+        # Keep the published ingress port in sync with the configured port.
+        self.ingress.provide_ingress_requirements(port=config.port)
+
         env = self._build_environment(config)
-
-        # Create Pebble layer
         layer = self._build_pebble_layer(config, env)
-
-        # Add layer to container
         self.container.add_layer(SERVICE_NAME, layer, combine=True)
-
-        # Restart service if configuration changed
         self.container.replan()
 
-        # Wait for service to be ready
-        if not beszel.wait_for_ready(self.container):
-            self.unit.status = ops.MaintenanceStatus("Waiting for service to start")
-            return
-
-        # Set workload version
         version = beszel.get_version(self.container)
         if version:
             self.unit.set_workload_version(version)
-
-        self.unit.status = ops.ActiveStatus()
 
     def _build_environment(self, config: BeszelConfig) -> dict[str, str]:
         """Build environment variables for Beszel.
 
         Args:
-            config: Beszel configuration
+            config: Beszel configuration.
 
         Returns:
-            Environment variables dictionary
+            Environment variables dictionary.
         """
         env = {
             "PORT": str(config.port),
             "LOG_LEVEL": config.log_level.upper(),
         }
 
-        # Add OAuth configuration if available
         if self.oauth.is_client_created():
             provider_info = self.oauth.get_provider_info()
             if provider_info and provider_info.client_id and provider_info.client_secret:
@@ -277,7 +223,6 @@ class BeszelCharm(ops.CharmBase):
                 env["OIDC_ISSUER_URL"] = provider_info.issuer_url
                 env["OIDC_REDIRECT_URI"] = f"https://{config.external_hostname}/_/#/auth/oidc"
 
-        # Add S3 configuration if enabled and available
         if config.s3_backup_enabled:
             s3_params = self.s3.get_s3_connection_info()
             if s3_params:
@@ -293,16 +238,16 @@ class BeszelCharm(ops.CharmBase):
     def _build_pebble_layer(
         self, config: BeszelConfig, env: dict[str, str]
     ) -> ops.pebble.LayerDict:
-        """Build Pebble layer for Beszel.
+        """Build the Pebble layer for Beszel.
 
         Args:
-            config: Beszel configuration
-            env: Environment variables
+            config: Beszel configuration.
+            env: Environment variables.
 
         Returns:
-            Pebble layer dictionary
+            Pebble layer dictionary.
         """
-        layer: ops.pebble.LayerDict = {
+        return {
             "summary": "Beszel Hub service",
             "services": {
                 SERVICE_NAME: {
@@ -311,11 +256,11 @@ class BeszelCharm(ops.CharmBase):
                     "command": "/beszel serve",
                     "startup": "enabled",
                     "environment": env,
-                    "on-check-failure": {"beszel-ready": "restart"},
+                    "on-check-failure": {CHECK_NAME: "restart"},
                 }
             },
             "checks": {
-                "beszel-ready": {
+                CHECK_NAME: {
                     "override": "replace",
                     "level": "ready",
                     "http": {"url": f"http://localhost:{config.port}/"},
@@ -325,68 +270,48 @@ class BeszelCharm(ops.CharmBase):
             },
         }
 
-        return layer
+    def _admin_url(self, config: BeszelConfig) -> str:
+        """Return the best-known URL for reaching the Beszel Hub."""
+        if self.ingress.url:
+            return self.ingress.url
+        if config.external_hostname:
+            return f"https://{config.external_hostname}"
+        return f"http://{self.app.name}:{config.port}"
 
     def _on_get_admin_url_action(self, event: ops.ActionEvent) -> None:
-        """Handle get-admin-url action.
-
-        Args:
-            event: Action event
-        """
-        config = BeszelConfig.from_charm_config(self.config)
-
-        # Try to get URL from ingress first
-        if self.ingress.url:
-            url = self.ingress.url
-        elif config.external_hostname:
-            url = f"https://{config.external_hostname}"
-        else:
-            url = f"http://{self.app.name}:{config.port}"
-
-        event.set_results({"url": url})
+        config = self.load_config(BeszelConfig)
+        event.set_results({"url": self._admin_url(config)})
 
     def _on_create_agent_token_action(self, event: ops.ActionEvent) -> None:
-        """Handle create-agent-token action.
-
-        Args:
-            event: Action event
-        """
-        description = event.params.get("description", "")
+        params = event.load_params(CreateAgentTokenParams, errors="fail")
 
         if not self.container.can_connect():
             event.fail("Container not ready")
             return
 
-        token = beszel.create_agent_token(self.container, description)
-
+        token = beszel.create_agent_token(self.container, params.description)
         if not token:
             event.fail("Failed to create agent token")
             return
 
+        config = self.load_config(BeszelConfig)
         instructions = (
             "Use this token when configuring Beszel agents:\n\n"
             "1. Install the Beszel agent on the system to monitor\n"
             "2. Configure the agent with:\n"
-            f"   HUB_URL={self.ingress.url or f'http://{self.app.name}:8090'}\n"
+            f"   HUB_URL={self._admin_url(config)}\n"
             f"   TOKEN={token}\n"
             "3. Start the agent service\n\n"
             "See https://beszel.dev/guide/getting-started for more details."
         )
-
         event.set_results({"token": token, "instructions": instructions})
 
     def _on_backup_now_action(self, event: ops.ActionEvent) -> None:
-        """Handle backup-now action.
-
-        Args:
-            event: Action event
-        """
         if not self.container.can_connect():
             event.fail("Container not ready")
             return
 
         backup_info = beszel.create_backup(self.container)
-
         if not backup_info:
             event.fail("Failed to create backup")
             return
@@ -394,18 +319,11 @@ class BeszelCharm(ops.CharmBase):
         event.set_results(backup_info)
 
     def _on_list_backups_action(self, event: ops.ActionEvent) -> None:
-        """Handle list-backups action.
-
-        Args:
-            event: Action event
-        """
         if not self.container.can_connect():
             event.fail("Container not ready")
             return
 
-        backups = beszel.list_backups(self.container)
-
-        event.set_results({"backups": backups})
+        event.set_results({"backups": beszel.list_backups(self.container)})
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/unit/test_beszel.py
+++ b/tests/unit/test_beszel.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Ubuntu
+# See LICENSE file for licensing details.
+
+import pathlib
+
+import pytest
+from ops import testing
+
+import beszel
+from charm import BeszelCharm
+
+CONTAINER_NAME = "beszel"
+
+
+@pytest.fixture
+def container_with_data(tmp_path: pathlib.Path):
+    """Yield a connected workload container backed by a real temp directory."""
+    ctx = testing.Context(BeszelCharm)
+    container = testing.Container(
+        name=CONTAINER_NAME,
+        can_connect=True,
+        mounts={"beszel-data": testing.Mount(location="/beszel_data", source=str(tmp_path))},
+        execs={testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n")},
+    )
+    state_in = testing.State(leader=True, containers={container})
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        yield manager.charm.container, tmp_path
+
+
+def test_get_version(container_with_data):
+    container, _ = container_with_data
+    assert beszel.get_version(container) == "0.17.0"
+
+
+def test_get_version_empty(tmp_path: pathlib.Path):
+    ctx = testing.Context(BeszelCharm)
+    container = testing.Container(
+        name=CONTAINER_NAME,
+        can_connect=True,
+        execs={testing.Exec(["/beszel", "--version"], stdout="\n")},
+    )
+    with ctx(ctx.on.update_status(), testing.State(containers={container})) as manager:
+        assert beszel.get_version(manager.charm.container) is None
+
+
+def test_create_agent_token(container_with_data):
+    container, data_dir = container_with_data
+    (data_dir / "data.db").write_text("db")
+
+    token = beszel.create_agent_token(container, "my-agent")
+
+    assert token is not None
+    assert len(token) > 0
+
+
+def test_create_agent_token_no_database(container_with_data):
+    container, _ = container_with_data
+    assert beszel.create_agent_token(container) is None
+
+
+def test_create_backup(container_with_data):
+    container, data_dir = container_with_data
+    (data_dir / "data.db").write_text("db-contents")
+
+    info = beszel.create_backup(container)
+
+    assert info is not None
+    assert info["filename"].startswith("beszel-backup-")
+    assert (data_dir / "backups" / info["filename"]).read_text() == "db-contents"
+
+
+def test_create_backup_no_database(container_with_data):
+    container, _ = container_with_data
+    assert beszel.create_backup(container) is None
+
+
+def test_list_backups_empty(container_with_data):
+    container, _ = container_with_data
+    assert beszel.list_backups(container) == []
+
+
+def test_list_backups(container_with_data):
+    container, data_dir = container_with_data
+    backups = data_dir / "backups"
+    backups.mkdir()
+    (backups / "beszel-backup-20250101-120000.db").write_text("a")
+    (backups / "ignore.txt").write_text("b")
+
+    result = beszel.list_backups(container)
+
+    assert len(result) == 1
+    assert result[0]["filename"] == "beszel-backup-20250101-120000.db"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,344 +1,47 @@
 # Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
 
-import ops.testing
+import ops
 import pytest
+from ops import testing
 
-from charm import BeszelCharm, BeszelConfig
+from charm import BeszelCharm
 
 CONTAINER_NAME = "beszel"
-METADATA = {
-    "name": "beszel",
-    "containers": {
-        CONTAINER_NAME: {"resource": "beszel-image"},
-    },
-    "resources": {
-        "beszel-image": {"type": "oci-image"},
-    },
-    "storage": {
-        "beszel-data": {
-            "type": "filesystem",
-        },
-    },
-    "requires": {
-        "ingress": {"interface": "ingress"},
-        "oauth": {"interface": "oauth"},
-        "s3-credentials": {"interface": "s3"},
-    },
-}
 
-CONFIG = {
-    "options": {
-        "container-image": {"type": "string", "default": "henrygd/beszel:latest"},
-        "port": {"type": "int", "default": 8090},
-        "external-hostname": {"type": "string", "default": ""},
-        "s3-backup-enabled": {"type": "boolean", "default": False},
-        "s3-endpoint": {"type": "string", "default": ""},
-        "s3-bucket": {"type": "string", "default": ""},
-        "s3-region": {"type": "string", "default": "us-east-1"},
-        "log-level": {"type": "string", "default": "info"},
-    },
-}
-
-ACTIONS = {
-    "get-admin-url": {},
-    "create-agent-token": {
-        "params": {
-            "description": {"type": "string", "default": ""},
-        },
-    },
-    "backup-now": {},
-    "list-backups": {},
-}
+# A version exec that lets the charm reach ActiveStatus.
+VERSION_EXEC = {testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n")}
 
 
 @pytest.fixture
 def ctx():
-    """Create a testing context."""
-    return ops.testing.Context(BeszelCharm, meta=METADATA, actions=ACTIONS, config=CONFIG)
+    """Create a testing context that autoloads metadata from charmcraft.yaml."""
+    return testing.Context(BeszelCharm)
 
 
-def test_config_from_charm_config():
-    """Test BeszelConfig creation from charm config."""
-    config_data = {
-        "container-image": "custom/image:tag",
-        "port": 8091,
-        "external-hostname": "beszel.example.com",
-        "s3-backup-enabled": True,
-        "s3-endpoint": "https://s3.example.com",
-        "s3-bucket": "backups",
-        "s3-region": "us-west-2",
-        "log-level": "debug",
-    }
-
-    class MockConfig:
-        def get(self, key, default=None):
-            return config_data.get(key, default)
-
-    config = BeszelConfig.from_charm_config(MockConfig())  # type: ignore[arg-type]
-
-    assert config.container_image == "custom/image:tag"
-    assert config.port == 8091
-    assert config.external_hostname == "beszel.example.com"
-    assert config.s3_backup_enabled is True
-    assert config.s3_endpoint == "https://s3.example.com"
-    assert config.s3_bucket == "backups"
-    assert config.s3_region == "us-west-2"
-    assert config.log_level == "debug"
+def _container(can_connect: bool = True, *, with_storage: bool = True, execs=None):
+    """Build a container, optionally with the data storage mounted and execs set."""
+    kwargs = {}
+    if with_storage:
+        kwargs["mounts"] = {"beszel-data": testing.Mount(location="/beszel_data", source="/tmp")}
+    if execs is not None:
+        kwargs["execs"] = execs
+    return testing.Container(name=CONTAINER_NAME, can_connect=can_connect, **kwargs)
 
 
-def test_config_defaults():
-    """Test BeszelConfig default values."""
-
-    class MockConfig:
-        def get(self, key, default=None):
-            return default
-
-    config = BeszelConfig.from_charm_config(MockConfig())  # type: ignore[arg-type]
-
-    assert config.container_image == "henrygd/beszel:latest"
-    assert config.port == 8090
-    assert config.external_hostname == ""
-    assert config.s3_backup_enabled is False
-    assert config.s3_endpoint == ""
-    assert config.s3_bucket == ""
-    assert config.s3_region == "us-east-1"
-    assert config.log_level == "info"
-
-
-def test_pebble_ready_without_storage(ctx: ops.testing.Context):
-    """Test pebble-ready without storage attached."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
+def test_pebble_ready_without_storage(ctx: testing.Context):
+    state_in = testing.State(leader=True, containers={_container(with_storage=False)})
 
     state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
 
     assert state_out.unit_status == ops.BlockedStatus("Storage not attached")
 
 
-def test_pebble_ready_with_storage(ctx: ops.testing.Context):
-    """Test pebble-ready with storage attached."""
-    state_in = ops.testing.State(
+def test_container_not_ready(ctx: testing.Context):
+    state_in = testing.State(
         leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                layers={},
-                service_statuses={},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
-
-    # Should configure the service
-    container = state_out.get_container(CONTAINER_NAME)
-    assert "beszel" in container.layers
-
-    # Check Pebble layer configuration
-    layer = container.layers["beszel"]
-    assert "beszel" in layer.services
-    service = layer.services["beszel"]
-    assert service.command == "/beszel serve"
-    assert service.startup == "enabled"
-    assert "PORT" in service.environment
-    assert service.environment["PORT"] == "8090"
-
-
-def test_config_changed_updates_service(ctx: ops.testing.Context):
-    """Test that config-changed updates the service configuration."""
-    # Initial state with default config
-    state_in = ops.testing.State(
-        leader=True,
-        config={"port": 8091, "log-level": "debug"},
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                layers={},
-                service_statuses={},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8091"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.config_changed(), state_in)
-
-    # Verify service has updated environment
-    container = state_out.get_container(CONTAINER_NAME)
-    layer = container.layers["beszel"]
-    service = layer.services["beszel"]
-    assert service.environment["PORT"] == "8091"
-    assert service.environment["LOG_LEVEL"] == "DEBUG"
-
-
-def test_health_check_configuration(ctx: ops.testing.Context):
-    """Test that health checks are properly configured."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
-
-    container = state_out.get_container(CONTAINER_NAME)
-    layer = container.layers["beszel"]
-
-    assert "beszel-ready" in layer.checks
-    check = layer.checks["beszel-ready"]
-    assert check.level == "ready" or check.level.value == "ready"  # type: ignore[union-attr]
-    assert check.http is not None
-    assert check.http.get("url") == "http://localhost:8090/"
-    assert check.period == "10s"
-    assert check.threshold == 3
-
-
-def test_get_admin_url_action_no_ingress(ctx: ops.testing.Context):
-    """Test get-admin-url action without ingress."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    ctx.run(ctx.on.action("get-admin-url"), state_in)
-
-    assert ctx.action_results.get("url") == "http://beszel:8090"  # type: ignore[union-attr]
-
-
-def test_get_admin_url_action_with_external_hostname(ctx: ops.testing.Context):
-    """Test get-admin-url action with external hostname configured."""
-    state_in = ops.testing.State(
-        leader=True,
-        config={"external-hostname": "beszel.example.com"},
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    ctx.run(ctx.on.action("get-admin-url"), state_in)
-
-    assert ctx.action_results.get("url") == "https://beszel.example.com"  # type: ignore[union-attr]
-
-
-def test_create_agent_token_action(ctx: ops.testing.Context, monkeypatch):
-    """Test create-agent-token action."""
-    # Mock the create_agent_token function to return a fake token
-    import beszel
-
-    monkeypatch.setattr(
-        beszel, "create_agent_token", lambda container, description: "fake-token-123"
-    )
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    ctx.run(ctx.on.action("create-agent-token", params={"description": "test"}), state_in)
-
-    # Should return a token
-    assert "token" in ctx.action_results  # type: ignore[operator]
-    assert len(ctx.action_results["token"]) > 0  # type: ignore[index]
-
-    # Should include instructions
-    assert "instructions" in ctx.action_results  # type: ignore[operator]
-    assert "HUB_URL" in ctx.action_results["instructions"]  # type: ignore[index]
-
-
-def test_create_agent_token_action_container_not_ready(ctx: ops.testing.Context):
-    """Test create-agent-token action when container is not ready."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=False,
-            )
-        ],
-    )
-
-    with pytest.raises(ops.testing.ActionFailed, match="Container not ready"):
-        ctx.run(ctx.on.action("create-agent-token"), state_in)
-
-
-def test_list_backups_action_no_backups(ctx: ops.testing.Context):
-    """Test list-backups action with no backups."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    ctx.run(ctx.on.action("list-backups"), state_in)
-
-    assert "backups" in ctx.action_results  # type: ignore[operator]
-    # Result should be an empty list or serialized empty list
-    backups = ctx.action_results["backups"]  # type: ignore[index]
-    assert backups == [] or backups == "[]"
-
-
-def test_container_not_ready(ctx: ops.testing.Context):
-    """Test that charm waits when container is not ready."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=False,
-            )
-        ],
+        containers={_container(can_connect=False)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
     state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
@@ -346,226 +49,77 @@ def test_container_not_ready(ctx: ops.testing.Context):
     assert state_out.unit_status == ops.WaitingStatus("Waiting for Pebble")
 
 
-def test_oauth_client_config_without_external_hostname(ctx: ops.testing.Context):
-    """Test that OAuth client config is None without external hostname."""
-    state_in = ops.testing.State(leader=True)
-
-    with ctx(ctx.on.install(), state_in) as manager:
-        charm = manager.charm
-        assert charm._get_oauth_client_config() is None
-
-
-def test_oauth_client_config_with_external_hostname(ctx: ops.testing.Context):
-    """Test OAuth client config with external hostname."""
-    state_in = ops.testing.State(leader=True, config={"external-hostname": "beszel.example.com"})
-
-    with ctx(ctx.on.install(), state_in) as manager:
-        charm = manager.charm
-        client_config = charm._get_oauth_client_config()
-
-        assert client_config is not None
-        assert "beszel.example.com" in client_config.redirect_uri
-        assert "openid" in client_config.scope
-
-
-def test_s3_environment_variables(ctx: ops.testing.Context):
-    """Test that S3 configuration sets environment variables."""
-    state_in = ops.testing.State(
+def test_pebble_ready_with_storage(ctx: testing.Context):
+    state_in = testing.State(
         leader=True,
-        config={
-            "s3-backup-enabled": True,
-            "s3-endpoint": "https://s3.example.com",
-            "s3-bucket": "my-backups",
-            "s3-region": "us-west-2",
-        },
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
-    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
 
-    # S3 env vars won't be set without relation data, but config should be read
-    container = state_out.get_container(CONTAINER_NAME)
-    assert "beszel" in container.layers
-
-
-def test_upgrade_charm(ctx: ops.testing.Context):
-    """Test upgrade-charm event."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.upgrade_charm(), state_in)
-
-    # Should reconfigure the workload
-    container = state_out.get_container(CONTAINER_NAME)
-    assert "beszel" in container.layers
-
-
-def test_config_changed_event(ctx: ops.testing.Context):
-    """Test config-changed event triggers reconfiguration."""
-    state_in = ops.testing.State(
-        leader=True,
-        config={"port": 8091},
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8091"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.config_changed(), state_in)
     assert state_out.unit_status == ops.ActiveStatus()
+    service = state_out.get_container(CONTAINER_NAME).layers["beszel"].services["beszel"]
+    assert service.command == "/beszel serve"
+    assert service.startup == "enabled"
+    assert service.environment["PORT"] == "8090"
 
 
-def test_backup_now_action(ctx: ops.testing.Context, monkeypatch):
-    """Test backup-now action."""
-    import beszel
+def test_config_changed_updates_service(ctx: testing.Context):
+    state_in = testing.State(
+        leader=True,
+        config={"port": 8091, "log-level": "debug"},
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
+    )
 
-    # Mock create_backup to return backup info
-    monkeypatch.setattr(
-        beszel,
-        "create_backup",
-        lambda container: {
-            "backup-path": "/beszel_data/backups/beszel-backup-20250101-120000.db",
-            "timestamp": "20250101-120000",
-            "filename": "beszel-backup-20250101-120000.db",
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.unit_status == ops.ActiveStatus()
+    service = state_out.get_container(CONTAINER_NAME).layers["beszel"].services["beszel"]
+    assert service.environment["PORT"] == "8091"
+    assert service.environment["LOG_LEVEL"] == "DEBUG"
+
+
+def test_invalid_port_blocks(ctx: testing.Context):
+    state_in = testing.State(
+        leader=True,
+        config={"port": 70000},
+        containers={_container()},
+        storages={testing.Storage("beszel-data", index=0)},
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.unit_status.name == "blocked"
+    assert "Invalid configuration" in state_out.unit_status.message
+
+
+def test_health_check_configuration(ctx: testing.Context):
+    state_in = testing.State(
+        leader=True,
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
+    )
+
+    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
+
+    check = state_out.get_container(CONTAINER_NAME).layers["beszel"].checks["beszel-ready"]
+    assert check.level == ops.pebble.CheckLevel.READY
+    assert check.http == {"url": "http://localhost:8090/"}
+    assert check.period == "10s"
+    assert check.threshold == 3
+
+
+def test_workload_version_set(ctx: testing.Context):
+    state_in = testing.State(
+        leader=True,
+        containers={
+            _container(
+                execs={testing.Exec(["/beszel", "--version"], stdout="beszel version 1.2.3\n")}
+            )
         },
-    )
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    ctx.run(ctx.on.action("backup-now"), state_in)
-
-    assert "backup-path" in ctx.action_results  # type: ignore[operator]
-    assert "timestamp" in ctx.action_results  # type: ignore[operator]
-
-
-def test_backup_now_action_failure(ctx: ops.testing.Context, monkeypatch):
-    """Test backup-now action when backup fails."""
-    import beszel
-
-    # Mock create_backup to return None (failure)
-    monkeypatch.setattr(beszel, "create_backup", lambda container: None)
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    with pytest.raises(ops.testing.ActionFailed, match="Failed to create backup"):
-        ctx.run(ctx.on.action("backup-now"), state_in)
-
-
-def test_list_backups_action_with_backups(ctx: ops.testing.Context, monkeypatch):
-    """Test list-backups action with existing backups."""
-    import beszel
-
-    # Mock list_backups to return backup list
-    monkeypatch.setattr(
-        beszel,
-        "list_backups",
-        lambda container: [
-            {
-                "filename": "beszel-backup-20250101-120000.db",
-                "path": "/beszel_data/backups/beszel-backup-20250101-120000.db",
-                "size": "1024",
-                "modified": "2025-01-01T12:00:00",
-            },
-            {
-                "filename": "beszel-backup-20250102-120000.db",
-                "path": "/beszel_data/backups/beszel-backup-20250102-120000.db",
-                "size": "2048",
-                "modified": "2025-01-02T12:00:00",
-            },
-        ],
-    )
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    ctx.run(ctx.on.action("list-backups"), state_in)
-
-    assert "backups" in ctx.action_results  # type: ignore[operator]
-    # Results is already the list
-    backups = ctx.action_results["backups"]  # type: ignore[index]
-    assert len(backups) == 2
-    assert backups[0]["filename"] == "beszel-backup-20250101-120000.db"
-
-
-def test_workload_version_set(ctx: ops.testing.Context):
-    """Test that workload version is set when available."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 1.2.3\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
     state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
@@ -573,272 +127,185 @@ def test_workload_version_set(ctx: ops.testing.Context):
     assert state_out.workload_version == "1.2.3"
 
 
-def test_storage_check_keyerror(ctx: ops.testing.Context, monkeypatch):
-    """Test storage check handles KeyError."""
-
-    # Patch model.storages to raise KeyError
-    def mock_storages_getitem(self, key):
-        raise KeyError(key)
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-    )
-
-    # Run pebble_ready which will trigger storage check
-    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
-
-    assert state_out.unit_status == ops.BlockedStatus("Storage not attached")
-
-
-def test_backup_now_action_container_not_ready(ctx: ops.testing.Context):
-    """Test backup-now action when container is not ready."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=False,
-            )
-        ],
-    )
-
-    with pytest.raises(ops.testing.ActionFailed, match="Container not ready"):
-        ctx.run(ctx.on.action("backup-now"), state_in)
-
-
-def test_list_backups_action_container_not_ready(ctx: ops.testing.Context):
-    """Test list-backups action when container is not ready."""
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=False,
-            )
-        ],
-    )
-
-    with pytest.raises(ops.testing.ActionFailed, match="Container not ready"):
-        ctx.run(ctx.on.action("list-backups"), state_in)
-
-
-def test_wait_for_ready_fails(ctx: ops.testing.Context, monkeypatch):
-    """Test when wait_for_ready returns False."""
+def test_version_not_available(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
     import beszel
 
-    # Mock wait_for_ready to return False
-    monkeypatch.setattr(beszel, "wait_for_ready", lambda container: False)
-
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
-    )
-
-    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
-
-    assert state_out.unit_status == ops.MaintenanceStatus("Waiting for service to start")
-
-
-def test_version_not_available(ctx: ops.testing.Context, monkeypatch):
-    """Test when version is not available."""
-    import beszel
-
-    # Mock get_version to return None
     monkeypatch.setattr(beszel, "get_version", lambda container: None)
-
-    state_in = ops.testing.State(
+    state_in = testing.State(
         leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
     state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
 
-    # Should still reach active status even without version
     assert state_out.unit_status == ops.ActiveStatus()
-    # Workload version should not be set
     assert state_out.workload_version == ""
 
 
-def test_create_agent_token_fails(ctx: ops.testing.Context, monkeypatch):
-    """Test create-agent-token action when token creation fails."""
-    import beszel
-
-    # Mock create_agent_token to return None
-    monkeypatch.setattr(beszel, "create_agent_token", lambda container, description: None)
-
-    state_in = ops.testing.State(
+def test_upgrade_charm_reconfigures(ctx: testing.Context):
+    state_in = testing.State(
         leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
-    with pytest.raises(ops.testing.ActionFailed, match="Failed to create agent token"):
+    state_out = ctx.run(ctx.on.upgrade_charm(), state_in)
+
+    assert state_out.unit_status == ops.ActiveStatus()
+    assert "beszel" in state_out.get_container(CONTAINER_NAME).layers
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, "http://beszel:8090"),
+        ({"external-hostname": "beszel.example.com"}, "https://beszel.example.com"),
+    ],
+)
+def test_get_admin_url_action(ctx: testing.Context, config: dict, expected: str):
+    state_in = testing.State(leader=True, config=config, containers={_container()})
+
+    ctx.run(ctx.on.action("get-admin-url"), state_in)
+
+    assert ctx.action_results == {"url": expected}
+
+
+def test_create_agent_token_action(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import beszel
+
+    monkeypatch.setattr(beszel, "create_agent_token", lambda container, description: "fake-token")
+    state_in = testing.State(leader=True, containers={_container()})
+
+    ctx.run(ctx.on.action("create-agent-token", params={"description": "test"}), state_in)
+
+    results = ctx.action_results
+    assert results is not None
+    assert results["token"] == "fake-token"
+    assert "HUB_URL" in results["instructions"]
+
+
+def test_create_agent_token_action_failure(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import beszel
+
+    monkeypatch.setattr(beszel, "create_agent_token", lambda container, description: None)
+    state_in = testing.State(leader=True, containers={_container()})
+
+    with pytest.raises(testing.ActionFailed, match="Failed to create agent token"):
         ctx.run(ctx.on.action("create-agent-token"), state_in)
 
 
-def test_storage_empty_list(ctx: ops.testing.Context):
-    """Test when storage list is empty."""
-    # Storage exists in metadata but hasn't been attached yet
-    state_in = ops.testing.State(
-        leader=True,
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-            )
-        ],
-        storages=[],  # Empty list - no storage attached
+def test_backup_now_action(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import beszel
+
+    monkeypatch.setattr(
+        beszel,
+        "create_backup",
+        lambda container: {"backup-path": "/beszel_data/backups/b.db", "timestamp": "t"},
     )
+    state_in = testing.State(leader=True, containers={_container()})
 
-    state_out = ctx.run(ctx.on.pebble_ready(state_in.get_container(CONTAINER_NAME)), state_in)
+    ctx.run(ctx.on.action("backup-now"), state_in)
 
-    assert state_out.unit_status == ops.BlockedStatus("Storage not attached")
+    assert ctx.action_results == {"backup-path": "/beszel_data/backups/b.db", "timestamp": "t"}
 
 
-def test_oauth_environment_variables(ctx: ops.testing.Context, monkeypatch):
-    """Test that OAuth configuration sets environment variables."""
-    state_in = ops.testing.State(
+def test_backup_now_action_failure(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import beszel
+
+    monkeypatch.setattr(beszel, "create_backup", lambda container: None)
+    state_in = testing.State(leader=True, containers={_container()})
+
+    with pytest.raises(testing.ActionFailed, match="Failed to create backup"):
+        ctx.run(ctx.on.action("backup-now"), state_in)
+
+
+def test_list_backups_action(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import beszel
+
+    backups = [{"filename": "b.db", "path": "/p", "size": "1", "modified": ""}]
+    monkeypatch.setattr(beszel, "list_backups", lambda container: backups)
+    state_in = testing.State(leader=True, containers={_container()})
+
+    ctx.run(ctx.on.action("list-backups"), state_in)
+
+    assert ctx.action_results == {"backups": backups}
+
+
+@pytest.mark.parametrize("action", ["create-agent-token", "backup-now", "list-backups"])
+def test_action_container_not_ready(ctx: testing.Context, action: str):
+    state_in = testing.State(leader=True, containers={_container(can_connect=False)})
+
+    with pytest.raises(testing.ActionFailed, match="Container not ready"):
+        ctx.run(ctx.on.action(action), state_in)
+
+
+@pytest.mark.parametrize(
+    ("config", "is_none"),
+    [({}, True), ({"external-hostname": "beszel.example.com"}, False)],
+)
+def test_oauth_client_config(ctx: testing.Context, config: dict, is_none: bool):
+    state_in = testing.State(leader=True, config=config, containers={_container()})
+
+    with ctx(ctx.on.install(), state_in) as manager:
+        client_config = manager.charm._get_oauth_client_config()
+        manager.run()
+
+    assert (client_config is None) is is_none
+    if client_config is not None:
+        assert "beszel.example.com" in client_config.redirect_uri
+        assert "openid" in client_config.scope
+
+
+def test_oauth_environment_variables(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    import unittest.mock
+
+    state_in = testing.State(
         leader=True,
         config={"external-hostname": "beszel.example.com"},
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
-    # Use context manager to mock OAuth methods
     with ctx(ctx.on.config_changed(), state_in) as manager:
-        charm = manager.charm
-
-        # Mock OAuth to return provider info
-        import unittest.mock
-
-        mock_provider_info = unittest.mock.Mock()
-        mock_provider_info.client_id = "test-client-id"
-        mock_provider_info.client_secret = "test-client-secret"
-        mock_provider_info.issuer_url = "https://issuer.example.com"
-
-        monkeypatch.setattr(charm.oauth, "is_client_created", lambda: True)
-        monkeypatch.setattr(charm.oauth, "get_provider_info", lambda: mock_provider_info)
-
+        provider_info = unittest.mock.Mock()
+        provider_info.client_id = "test-client-id"
+        provider_info.client_secret = "test-client-secret"
+        provider_info.issuer_url = "https://issuer.example.com"
+        monkeypatch.setattr(manager.charm.oauth, "is_client_created", lambda: True)
+        monkeypatch.setattr(manager.charm.oauth, "get_provider_info", lambda: provider_info)
         state_out = manager.run()
 
-    # Check that OAuth env vars were set
-    container = state_out.get_container(CONTAINER_NAME)
-    layer = container.layers["beszel"]
-    service = layer.services["beszel"]
-
-    assert "OIDC_CLIENT_ID" in service.environment
-    assert service.environment["OIDC_CLIENT_ID"] == "test-client-id"
-    assert "OIDC_CLIENT_SECRET" in service.environment
-    assert service.environment["OIDC_CLIENT_SECRET"] == "test-client-secret"
-    assert "OIDC_ISSUER_URL" in service.environment
-    assert service.environment["OIDC_ISSUER_URL"] == "https://issuer.example.com"
-    assert "OIDC_REDIRECT_URI" in service.environment
+    env = state_out.get_container(CONTAINER_NAME).layers["beszel"].services["beszel"].environment
+    assert env["OIDC_CLIENT_ID"] == "test-client-id"
+    assert env["OIDC_CLIENT_SECRET"] == "test-client-secret"
+    assert env["OIDC_ISSUER_URL"] == "https://issuer.example.com"
+    assert "OIDC_REDIRECT_URI" in env
 
 
-def test_s3_environment_variables_with_relation(ctx: ops.testing.Context, monkeypatch):
-    """Test that S3 configuration sets environment variables from relation."""
-    state_in = ops.testing.State(
+def test_s3_environment_variables(ctx: testing.Context, monkeypatch: pytest.MonkeyPatch):
+    state_in = testing.State(
         leader=True,
-        config={
-            "s3-backup-enabled": True,
-            "s3-endpoint": "https://fallback.example.com",
-            "s3-bucket": "fallback-bucket",
-        },
-        containers=[
-            ops.testing.Container(
-                name=CONTAINER_NAME,
-                can_connect=True,
-                mounts={"beszel-data": ops.testing.Mount(location="/beszel_data", source="tmpfs")},
-                execs={
-                    ops.testing.Exec(["/beszel", "--version"], stdout="beszel version 0.17.0\n"),
-                    ops.testing.Exec(
-                        ["/beszel", "health", "--url", "http://localhost:8090"], return_code=0
-                    ),
-                },
-            )
-        ],
-        storages=[ops.testing.Storage("beszel-data", index=0)],
+        config={"s3-backup-enabled": True},
+        containers={_container(execs=VERSION_EXEC)},
+        storages={testing.Storage("beszel-data", index=0)},
     )
 
-    # Use context manager to mock S3 methods
+    s3_params = {
+        "endpoint": "https://s3.example.com",
+        "bucket": "my-bucket",
+        "region": "us-west-2",
+        "access-key": "test-access-key",
+        "secret-key": "test-secret-key",
+    }
     with ctx(ctx.on.config_changed(), state_in) as manager:
-        charm = manager.charm
-
-        # Mock S3 to return connection info
-        s3_params = {
-            "endpoint": "https://s3.example.com",
-            "bucket": "my-bucket",
-            "region": "us-west-2",
-            "access-key": "test-access-key",
-            "secret-key": "test-secret-key",
-        }
-
-        monkeypatch.setattr(charm.s3, "get_s3_connection_info", lambda: s3_params)
-
+        monkeypatch.setattr(manager.charm.s3, "get_s3_connection_info", lambda: s3_params)
         state_out = manager.run()
 
-    # Check that S3 env vars were set from relation
-    container = state_out.get_container(CONTAINER_NAME)
-    layer = container.layers["beszel"]
-    service = layer.services["beszel"]
-
-    assert "S3_BACKUP_ENABLED" in service.environment
-    assert service.environment["S3_BACKUP_ENABLED"] == "true"
-    assert "S3_ENDPOINT" in service.environment
-    assert service.environment["S3_ENDPOINT"] == "https://s3.example.com"
-    assert "S3_BUCKET" in service.environment
-    assert service.environment["S3_BUCKET"] == "my-bucket"
-    assert "S3_REGION" in service.environment
-    assert service.environment["S3_REGION"] == "us-west-2"
-    assert "S3_ACCESS_KEY_ID" in service.environment
-    assert service.environment["S3_ACCESS_KEY_ID"] == "test-access-key"
-    assert "S3_SECRET_ACCESS_KEY" in service.environment
-    assert service.environment["S3_SECRET_ACCESS_KEY"] == "test-secret-key"
+    env = state_out.get_container(CONTAINER_NAME).layers["beszel"].services["beszel"].environment
+    assert env["S3_BACKUP_ENABLED"] == "true"
+    assert env["S3_ENDPOINT"] == "https://s3.example.com"
+    assert env["S3_BUCKET"] == "my-bucket"
+    assert env["S3_REGION"] == "us-west-2"
+    assert env["S3_ACCESS_KEY_ID"] == "test-access-key"
+    assert env["S3_SECRET_ACCESS_KEY"] == "test-secret-key"


### PR DESCRIPTION
## Summary

I reviewed this charm against current best practice — the `canonical/operator` example charms (`examples/k8s-2-configurable`, `examples/k8s-4-action`) and the guidance in `charming-with-claude` — and **modernised it in place** (it is structurally sound: charmcraft 3.x, ops 3, `uv`, Jubilant, a single reconciler, a separate workload module, CI + zizmor + dependabot + pre-commit). A rewrite was not warranted; these are focused, incremental changes that bring the charm up to the idioms the reference repos establish.

All changes are verified locally: `ruff check`, `ruff format --check`, `codespell`, `pyright` all clean, and **31 unit tests pass with coverage up from 77% → 92%** (`fail_under = 80` now enforced).

## What changed

**Charm code (`src/charm.py`, `src/beszel.py`)**
- **Typed config** via `CharmBase.load_config(BeszelConfig)`, removing the hand-written `from_charm_config` mapping that re-listed every default. (matches `k8s-2-configurable`)
- **Typed action params** via `ActionEvent.load_params(CreateAgentTokenParams, errors="fail")`, replacing raw `event.params.get(...)`. (matches `k8s-4-action`)
- **`collect_unit_status` handler** for all status reporting, instead of setting `self.unit.status` imperatively across handlers. (matches `k8s-4-action`)
- **Removed the blocking `wait_for_ready`/`is_ready` polling** (with `time.sleep` loops in a hook) — readiness is already handled by the Pebble `ready` health check with `on-check-failure: restart`.
- **Fixed the hard-coded ingress port**: the configured `port` is now published to `IngressPerAppRequirer` and kept in sync on config changes (was always `8090`). The agent-token instructions also use the configured URL/port.
- Minor: `import pydantic` rather than `from pydantic import ...` per the project style guide; dropped a dead `TYPE_CHECKING`/constant.

**Metadata (`charmcraft.yaml`)**
- Added `assumes: [juju >= 3.6, k8s-api]` so deployment fails fast on incompatible controllers.
- Added `additionalProperties: false` to every action.

**Tests**
- `tests/unit/test_charm.py`: `testing.Context(BeszelCharm)` now **autoloads metadata from `charmcraft.yaml`** — the `METADATA`/`CONFIG`/`ACTIONS` override dicts are gone (they were leftovers from older Scenario and drift from the real metadata). Tests assert on `collect_unit_status` output, use `parametrize`, and drop the `# type: ignore` noise.
- New `tests/unit/test_beszel.py` exercises the workload module against a real Pebble filesystem (mounted temp dir) rather than only monkeypatching it.

**Docs**
- `CHANGELOG.md` `[Unreleased]` updated; README "Requirements" bumped to Juju >= 3.6 to match the new `assumes` block.

## What I deliberately did NOT change
- **Observability/COS** (tracing, metrics, logs, dashboards). The guidance recommends wiring these by default, but it's a substantial, separable piece of work and would bloat this PR.
- **`beszel.create_agent_token` / `create_backup` semantics.** These remain placeholder-ish (the token is a random `secrets.token_urlsafe`, the backup is a plain file copy of the SQLite DB). Making them real needs Beszel API/CLI knowledge and is out of scope here — flagging it as a known limitation. **Integration tests (`tests/integration/`).** Left as-is: I can't run a live cluster in this environment, so I didn't want to churn them blind. ⚠️ Reviewer please double-check `test_http_service_responds` / `test_service_is_running`, which `juju exec` `curl`/shell inside the workload container — the upstream `henrygd/beszel` image is a `scratch` image with no shell or `curl`, so these likely need rewriting (e.g. drive the Pebble health check or hit the service from the test runner).
- The committed `.claude/transcripts/` and the `DEPLOYMENT_SUMMARY.md` / `FINAL_SUMMARY.md` / `PLAN.md` summary docs — left for you to decide on.

## Reviewer notes
- `BeszelConfig` stays a Pydantic model (pydantic is already a transitive dep via the traefik ingress lib) so `load_config` gives free `port` range validation; invalid config → `BlockedStatus("Invalid configuration: ...")` via collect-status (new test `test_invalid_port_blocks`).
- Config is read directly (not via `load_config`) in `__init__` for the two values the requirers need at construction time, so a bad config value can't crash every hook.

https://claude.ai/code/session_0149fp8jxYgYMH4sMRi2Ray6

---
_Generated by [Claude Code](https://claude.ai/code/session_0149fp8jxYgYMH4sMRi2Ray6)_